### PR TITLE
remove python-support dependency due to deprecation in ubuntu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,12 @@
+python-socketcache (0.1.1) unstable; urgency=low
+
+  * Removing python-support due to deprecation.
+
+ -- Derp Ston <derpston+packaging@sleepygeek.org>  Thu, 15 Mar 2018 14:02:00 +0000
+
+
 python-socketcache (0.1.0) unstable; urgency=low
 
   * Initial release.
 
  -- Derp Ston <derpston+packaging@sleepygeek.org>  Tue, 20 Nov 2012 03:20:00 +0000
-
-

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Derp Ston <derpston+packaging@sleepygeek.org>
 Build-Depends:
     debhelper (>= 6.0.0),
-    python-support (>= 0.90)
 Standards-Version: 3.9.1
 
 Package: python-socketcache

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-
 from distutils.core import setup
 
 setup(
       name = 'socketcache'
-   ,  version = '0.1.0'
+   ,  version = '0.1.1'
    ,  description = 'Maintains a cache of socket objects'
    ,  long_description = """A simple pure python cache of UDP socket objects, supporting a \
 custom TTL, IPv{4,6} and random balancing. Intended to assist in sending a lot of UDP packets \
@@ -16,4 +15,3 @@ have a caching resolver at all, making it a good idea for the application to man
    ,  packages = ['']
    ,  package_dir = {'': 'src'}
    )
-

--- a/src/socketcache.py
+++ b/src/socketcache.py
@@ -2,7 +2,7 @@ import random
 import socket
 import time
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 class UDPSocketCache:
    """Maintains a cache of SOCK_DGRAM socket objects for `ttl` seconds, preferring IPv6 over IPv4 and respecting random balancing. `ttl` defaults to 60 seconds, and `family` defaults to both IPv4 and v6."""
@@ -54,4 +54,3 @@ class UDPSocketCache:
          return random.choice(self._v4sockets)
       else:
          return None
-


### PR DESCRIPTION
Prerequisite for https://github.com/derpston/python-graphiteudp/pull/6 which removes python-support from python-graphiteudp, and socketcache is a dependency of this, so need to remove here also